### PR TITLE
Add Web Analytics beacon + privacy policy & Impressum fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
                 <div class="terms-intro">
                     Diese Seite ist <strong>keine offizielle Seite von fraenk</strong> oder der Telekom Deutschland GmbH.<br><br>
                     Es wird lediglich ein Einladungs-Code für "fraenk for friends" angeboten. Alle relevanten Informationen findest du auf der <a href="https://fraenk.de/fraenk-for-friends" target="_blank" rel="noopener">offiziellen Seite von fraenk</a>.<br><br>
-                    Es werden keine persönlichen Daten von dir gespeichert.<br>
+                    Diese Seite setzt keine Tracking-Cookies und nutzt nur eine cookielose, datenschutzfreundliche Reichweitenmessung. Mehr dazu in der <a href="#" onclick="hideTerms(); showDatenschutz(); return false;">Datenschutzerklärung</a>.<br>
                     Im Nachfolgenden findest du die <a href="https://fraenk.de/Teilnahmebedingungen_fraenk_for_friends.pdf" target="_blank" rel="noopener">Teilnahmebedingungen</a> von <a href="https://fraenk.de/" target="_blank" rel="noopener">fraenk</a>.<br><br>
                     In diesen Teilnahmebedingungen bist du der "geworbene Freund" und hast Anspruch auf +5 GB mehr Datenvolumen pro Monat.<br><br>
                 </div>
@@ -175,7 +175,7 @@
             </div>
             
             <div class="modal-body">
-                <h3>Angaben gemäß § 5 TMG:</h3>
+                <h3>Angaben gemäß § 5 DDG:</h3>
                 <p>
                     Nico Engelmann<br>
                     Richard-Dilger-Str. 23<br>
@@ -186,7 +186,7 @@
                 <h3>Kontakt:</h3>
                 <p>E-Mail: nico@fraenk-for-friends.online</p>
 
-                <h3>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</h3>
+                <h3>Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV:</h3>
                 <p>
                     Nico Engelmann<br>
                     Richard-Dilger-Str. 23<br>
@@ -196,6 +196,45 @@
 
                 <h3>Haftungsausschluss:</h3>
                 <p>Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen.</p>
+            </div>
+        </div>
+    </div>
+
+    <div id="datenschutz-modal" class="modal" role="dialog" aria-labelledby="datenschutz-title" aria-modal="true">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="datenschutz-title" class="highlight">Datenschutzerklärung</h2>
+                <button class="close-btn" onclick="hideDatenschutz()" aria-label="Schließen">&times;</button>
+            </div>
+
+            <div class="modal-body">
+                <h3>1. Verantwortlicher</h3>
+                <p>
+                    Nico Engelmann<br>
+                    Richard-Dilger-Str. 23<br>
+                    78476 Allensbach, Deutschland<br>
+                    E-Mail: nico@fraenk-for-friends.online
+                </p>
+
+                <h3>2. Allgemeines</h3>
+                <p>Diese Website ist ein rein informatives Angebot. Wir behandeln deine personenbezogenen Daten vertraulich und entsprechend der DSGVO sowie dem TDDDG. Es werden keine Tracking-Cookies gesetzt und es findet keine geräteübergreifende Wiedererkennung statt.</p>
+
+                <h3>3. Hosting (Cloudflare)</h3>
+                <p>Diese Website wird über Cloudflare (Cloudflare, Inc., 101 Townsend St, San Francisco, CA 94107, USA) bereitgestellt. Beim Aufruf verarbeitet Cloudflare technisch notwendige Verbindungsdaten (u.a. IP-Adresse, Datum/Uhrzeit, angeforderte Datei, Browsertyp), um Auslieferung und Sicherheit zu gewährleisten. Rechtsgrundlage ist unser berechtigtes Interesse an einem sicheren und effizienten Betrieb (Art. 6 Abs. 1 lit. f DSGVO). Dabei kann ein technisch notwendiges Sicherheits-Cookie (z.&nbsp;B. „__cf_bm“) gesetzt werden.</p>
+
+                <h3>4. Reichweitenmessung mit Cloudflare Web Analytics</h3>
+                <p>Zur statistischen Auswertung der Nutzung verwenden wir Cloudflare Web Analytics. Der Dienst arbeitet <strong>cookielos</strong>, verzichtet auf Fingerprinting und legt keine geräte- oder nutzerbezogenen Kennungen an. Verarbeitet werden in aggregierter, nicht zur Identifikation einzelner Personen geeigneter Form: aufgerufene Seite, Verweis-/Referrer-Adresse, ungefähres Herkunftsland (aus der IP-Adresse abgeleitet, ohne dauerhafte Speicherung der IP), Browser-/Gerätetyp und Performance-Daten. Zweck ist das Verständnis von Reichweite und Herkunft der Besucher. Rechtsgrundlage ist unser berechtigtes Interesse an einer bedarfsgerechten Gestaltung des Angebots (Art. 6 Abs. 1 lit. f DSGVO). Da nicht auf Informationen in deinem Endgerät zugegriffen wird, ist hierfür keine Einwilligung nach § 25 TDDDG erforderlich.</p>
+
+                <h3>5. Auftragsverarbeitung &amp; Drittlandübermittlung</h3>
+                <p>Mit Cloudflare als Auftragsverarbeiter besteht ein Vertrag gemäß Art. 28 DSGVO. Soweit Daten in die USA übermittelt werden, stützt sich Cloudflare auf Standardvertragsklauseln sowie auf eine Zertifizierung unter dem EU-US Data Privacy Framework.</p>
+
+                <h3>6. Deine Rechte</h3>
+                <p>Du hast das Recht auf Auskunft (Art. 15), Berichtigung (Art. 16), Löschung (Art. 17), Einschränkung (Art. 18) und Datenübertragbarkeit (Art. 20) sowie ein <strong>Widerspruchsrecht</strong> gegen die auf berechtigtem Interesse beruhende Verarbeitung (Art. 21 DSGVO). Außerdem besteht ein Beschwerderecht bei einer Datenschutz-Aufsichtsbehörde. Eine formlose Nachricht an die oben genannte Adresse genügt.</p>
+
+                <h3>7. Verschlüsselung</h3>
+                <p>Diese Website nutzt aus Sicherheitsgründen eine SSL-/TLS-Verschlüsselung (https).</p>
+
+                <p style="opacity:.7;font-size:.9em;">Stand: Mai 2026</p>
             </div>
         </div>
     </div>
@@ -246,6 +285,7 @@
     <footer>
         <div class="footer-links">
             <button class="link-btn" onclick="showImpressum()">Impressum</button>
+            <button class="link-btn" onclick="showDatenschutz()">Datenschutz</button>
             <button class="link-btn" id="faq-btn">FAQ</button>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -342,5 +342,8 @@
             }
         });
     </script>
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "9e390d12d6b94d189e78f15b998788c2"}'></script>
+    <!-- End Cloudflare Web Analytics -->
 </body>
 </html> 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Variable declarations
-let modal, impressumModal, faqModal, code, termsToggle, termsText;
+let modal, impressumModal, faqModal, datenschutzModal, code, termsToggle, termsText;
 
 // Performance optimization
 document.addEventListener('DOMContentLoaded', function() {
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function() {
     modal = document.getElementById('terms-modal');
     impressumModal = document.getElementById('impressum-modal');
     faqModal = document.getElementById('faq-modal');
+    datenschutzModal = document.getElementById('datenschutz-modal');
     code = document.getElementById('code');
     termsToggle = document.getElementById('terms-toggle');
     termsText = document.querySelector('.terms-text');
@@ -188,6 +189,22 @@ function hideImpressum() {
     document.body.style.overflow = '';
 }
 
+// Show datenschutz modal
+function showDatenschutz() {
+    if (!datenschutzModal) return;
+    
+    datenschutzModal.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+}
+
+// Hide datenschutz modal
+function hideDatenschutz() {
+    if (!datenschutzModal) return;
+    
+    datenschutzModal.style.display = 'none';
+    document.body.style.overflow = '';
+}
+
 // Update window click handler for all modals
 window.onclick = function(event) {
     if (!modal || !impressumModal || !faqModal) return;
@@ -198,6 +215,8 @@ window.onclick = function(event) {
         hideImpressum();
     } else if (event.target === faqModal) {
         hideFaq();
+    } else if (datenschutzModal && event.target === datenschutzModal) {
+        hideDatenschutz();
     }
 }
 
@@ -212,6 +231,8 @@ document.addEventListener('keydown', function(event) {
             hideImpressum();
         } else if (faqModal.style.display === 'block') {
             hideFaq();
+        } else if (datenschutzModal && datenschutzModal.style.display === 'block') {
+            hideDatenschutz();
         }
     }
 }); 


### PR DESCRIPTION
## What
1. Adds the **Cloudflare Web Analytics** beacon (cookieless) to `index.html`.
2. Adds a **Datenschutzerklärung** (privacy policy) modal + footer link — required because the beacon processes personal data (IP→country, referrer, page, UA) under GDPR.
3. Rewords the *„keine persönlichen Daten“* note so it stays accurate with analytics enabled.
4. Fixes outdated **Impressum** citations: `§ 5 TMG → § 5 DDG`, `§ 55 Abs. 2 RStV → § 18 Abs. 2 MStV`.

## Legal basis
- **No cookie banner needed**: Cloudflare Web Analytics is cookieless → no consent under § 25 TDDDG.
- **GDPR**: legitimate interest (Art. 6(1)(f)); processor = Cloudflare (DPA/Art. 28); US transfer via SCCs + EU-US DPF — all disclosed in the new privacy policy.

## Notes
- Web Analytics site provisioned with `auto_install: false`, so this in-code beacon is the single source.
- ⚠️ The privacy text is a solid standard draft — have it reviewed (e.g. eRecht24 / Dr. Schwenke generator) before relying on it; not legal advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)